### PR TITLE
Remove header logo and enlarge title

### DIFF
--- a/app/components/YearSquares.tsx
+++ b/app/components/YearSquares.tsx
@@ -62,14 +62,9 @@ export default function YearSquares(props: YearSquaresProps) {
       >
         {/* App name */}
         <div className="w-full mb-4 flex items-center justify-center">
-          <div className="inline-flex items-center gap-3">
-            <span className="inline-flex items-center justify-center w-8 h-8 rounded-md bg-white/10 text-neutral-100 font-semibold">
-              SC
-            </span>
-            <span className="text-sm md:text-base font-semibold tracking-tight">
-              Simpli Calendar
-            </span>
-          </div>
+          <span className="text-lg md:text-xl font-semibold tracking-tight">
+            Simpli Calendar
+          </span>
         </div>
         {/* Header */}
         <div className="mb-6 text-center">

--- a/app/components/YearSquares.tsx
+++ b/app/components/YearSquares.tsx
@@ -69,10 +69,10 @@ export default function YearSquares(props: YearSquaresProps) {
         {/* Header */}
         <div className="mb-6 text-center">
           <div>
-            <span className="text-2xl md:text-3xl font-semibold tracking-tight">
+            <span className="text-lg sm:text-xl font-semibold tracking-tight">
               Today
             </span>{" "}
-            <span className="md:text-3xl font-semibold tracking-tight">
+            <span className="text-lg sm:text-xl font-semibold tracking-tight">
               is the {mounted && todayIndex != null ? todayIndex : "--"}
               {mounted && todayIndex != null ? nth(todayIndex) : ""} day of{" "}
               {year}.

--- a/app/components/YearSquares.tsx
+++ b/app/components/YearSquares.tsx
@@ -62,7 +62,7 @@ export default function YearSquares(props: YearSquaresProps) {
       >
         {/* App name */}
         <div className="w-full mb-4 flex items-center justify-center">
-          <span className="text-lg md:text-xl font-semibold tracking-tight">
+          <span className="text-2xl sm:text-3xl font-semibold tracking-tight">
             Simpli Calendar
           </span>
         </div>


### PR DESCRIPTION
## Summary
- remove SC header logo
- enlarge Simpli Calendar text

## Testing
- `pnpm format app/components/YearSquares.tsx`
- `pnpm lint app/components/YearSquares.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b930eb96548321900570a3975e0e3b